### PR TITLE
Docker Improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+README.md
+LICENSE
+target
+docker-compose.yml
+Jenkinsfile
+Dockerfile
+mvnw
+mvnw.cmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder build/target/quickdrop-0.0.1-SNAPSHOT.jar app/quickdrop.jar
 
 WORKDIR /app
 
-VOLUME ["/app/db", "/app/log", "/files"]
+VOLUME ["/app/db", "/app/log", "/app/files"]
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,36 @@
-FROM openjdk:21-jdk-slim
+# Build the application using the maven image
+FROM maven:3.9.9 AS builder
+
+WORKDIR /build
+COPY . .
+RUN mvn clean package
+
+# Create a slimmed version of the Java JRE using the Corretto image
+FROM amazoncorretto:21.0.6-alpine AS corretto-jdk
+
+RUN apk add --no-cache binutils
+# Build small JRE image
+RUN $JAVA_HOME/bin/jlink \
+         --verbose \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=zip-4 \
+         --output /slim_jre
+
+# Use a small Linux distro for final image
+FROM alpine:latest
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Copy the JRE into Alpine image
+COPY --from=corretto-jdk /slim_jre $JAVA_HOME
+
+# Copy the compiled app into Alpine image
+COPY --from=builder build/target/quickdrop-0.0.1-SNAPSHOT.jar app/quickdrop.jar
 
 WORKDIR /app
-
-COPY target/quickdrop-0.0.1-SNAPSHOT.jar /app/quickdrop.jar
 
 VOLUME ["/app/db", "/app/log", "/files"]
 


### PR DESCRIPTION
**Drastically** reduces docker image size
- Build the application using the maven docker image (no longer need to compile the app locally).

- Use the Amazon Corretto JDK image for the JRE source.  (OpenJDK has been deprecated).  Create the small JRE using the jlink tool.

- Using the alpine distro as base; copy the generated JRE; copy the built application.

- Add dockerignore and fix volume