### PR TITLE
Update Spring Boot to version 3.3.10 (from 3.3.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
             spring-boot-starter-parent
         </artifactId>
         <version>
-            3.3.4
+            3.3.10
         </version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>


### PR DESCRIPTION
This fixes 16 security vulnerabilities.  
Six of which were High or Critical severity.