### PR TITLE
Add default home page setting

### DIFF
--- a/src/main/java/org/rostislav/quickdrop/controller/IndexViewController.java
+++ b/src/main/java/org/rostislav/quickdrop/controller/IndexViewController.java
@@ -2,7 +2,6 @@ package org.rostislav.quickdrop.controller;
 
 import org.rostislav.quickdrop.service.ApplicationSettingsService;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
@@ -14,10 +13,12 @@ public class IndexViewController {
     }
 
     @GetMapping("/")
-    public String getIndexPage(Model model) {
-        model.addAttribute("maxFileSize", applicationSettingsService.getFormattedMaxFileSize());
-        model.addAttribute("maxFileLifeTime", applicationSettingsService.getMaxFileLifeTime());
-        return "upload";
+    public String getIndexPage() {
+        String home = applicationSettingsService.getDefaultHomePage();
+        if ("list".equalsIgnoreCase(home) && applicationSettingsService.isFileListPageEnabled()) {
+            return "redirect:/file/list";
+        }
+        return "redirect:/file/upload";
     }
 
     @GetMapping("/error")

--- a/src/main/java/org/rostislav/quickdrop/entity/ApplicationSettingsEntity.java
+++ b/src/main/java/org/rostislav/quickdrop/entity/ApplicationSettingsEntity.java
@@ -23,6 +23,7 @@ public class ApplicationSettingsEntity {
     private boolean isFileListPageEnabled;
     private boolean isAdminDashboardButtonEnabled;
     private boolean disableEncryption;
+    private String defaultHomePage;
 
     public ApplicationSettingsEntity() {
     }
@@ -38,6 +39,7 @@ public class ApplicationSettingsEntity {
         this.isFileListPageEnabled = settings.isFileListPageEnabled();
         this.isAdminDashboardButtonEnabled = settings.isAdminDashboardButtonEnabled();
         this.disableEncryption = settings.isEncryptionDisabled();
+        this.defaultHomePage = settings.getDefaultHomePage();
     }
 
     public long getMaxFileSize() {
@@ -142,5 +144,13 @@ public class ApplicationSettingsEntity {
 
     public void setDisableEncryption(boolean disableEncryption) {
         this.disableEncryption = disableEncryption;
+    }
+
+    public String getDefaultHomePage() {
+        return defaultHomePage;
+    }
+
+    public void setDefaultHomePage(String defaultHomePage) {
+        this.defaultHomePage = defaultHomePage;
     }
 }

--- a/src/main/java/org/rostislav/quickdrop/model/ApplicationSettingsViewModel.java
+++ b/src/main/java/org/rostislav/quickdrop/model/ApplicationSettingsViewModel.java
@@ -16,6 +16,7 @@ public class ApplicationSettingsViewModel {
     private boolean isFileListPageEnabled;
     private boolean isAdminDashboardButtonEnabled;
     private boolean encryptionDisabled;
+    private String defaultHomePage;
 
     public ApplicationSettingsViewModel() {
     }
@@ -32,6 +33,7 @@ public class ApplicationSettingsViewModel {
         this.isFileListPageEnabled = settings.isFileListPageEnabled();
         this.isAdminDashboardButtonEnabled = settings.isAdminDashboardButtonEnabled();
         this.encryptionDisabled = settings.isDisableEncryption();
+        this.defaultHomePage = settings.getDefaultHomePage();
     }
 
     public Long getId() {
@@ -128,5 +130,13 @@ public class ApplicationSettingsViewModel {
 
     public void setEncryptionDisabled(boolean encryptionDisabled) {
         this.encryptionDisabled = encryptionDisabled;
+    }
+
+    public String getDefaultHomePage() {
+        return defaultHomePage;
+    }
+
+    public void setDefaultHomePage(String defaultHomePage) {
+        this.defaultHomePage = defaultHomePage;
     }
 }

--- a/src/main/java/org/rostislav/quickdrop/service/ApplicationSettingsService.java
+++ b/src/main/java/org/rostislav/quickdrop/service/ApplicationSettingsService.java
@@ -37,6 +37,7 @@ public class ApplicationSettingsService {
             settings.setFileListPageEnabled(true);
             settings.setAdminDashboardButtonEnabled(true);
             settings.setDisableEncryption(false);
+            settings.setDefaultHomePage("upload");
             settings = applicationSettingsRepository.save(settings);
             scheduleService.updateSchedule(settings.getFileDeletionCron(), settings.getMaxFileLifeTime());
             return settings;
@@ -58,6 +59,7 @@ public class ApplicationSettingsService {
         applicationSettingsEntity.setFileListPageEnabled(settings.isFileListPageEnabled());
         applicationSettingsEntity.setAdminDashboardButtonEnabled(settings.isAdminDashboardButtonEnabled());
         applicationSettingsEntity.setDisableEncryption(settings.isEncryptionDisabled());
+        applicationSettingsEntity.setDefaultHomePage(settings.getDefaultHomePage());
 
         if (appPassword != null && !appPassword.isEmpty()) {
             applicationSettingsEntity.setAppPasswordEnabled(settings.isAppPasswordEnabled());
@@ -140,5 +142,9 @@ public class ApplicationSettingsService {
 
     public boolean isEncryptionEnabled() {
         return !applicationSettings.isDisableEncryption();
+    }
+
+    public String getDefaultHomePage() {
+        return applicationSettings.getDefaultHomePage();
     }
 }

--- a/src/main/resources/db/migration/V5__Add_default_home_page.sql
+++ b/src/main/resources/db/migration/V5__Add_default_home_page.sql
@@ -1,0 +1,2 @@
+ALTER TABLE application_settings_entity
+    ADD COLUMN default_home_page VARCHAR(255) NOT NULL DEFAULT 'upload';

--- a/src/main/resources/templates/fileView.html
+++ b/src/main/resources/templates/fileView.html
@@ -43,7 +43,7 @@
                     <a class="nav-link" href="/file/list">View Files</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/">Upload File</a>
+                    <a class="nav-link" href="/file/upload">Upload File</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="/admin/dashboard" onclick="requestAdminPassword()"

--- a/src/main/resources/templates/listFiles.html
+++ b/src/main/resources/templates/listFiles.html
@@ -34,7 +34,7 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav ms-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="/">Upload File</a>
+                    <a class="nav-link" href="/file/upload">Upload File</a>
                 </li>
                 <li class="nav-item">
                     <!-- Admin Dashboard Button -->
@@ -78,7 +78,7 @@
     <div class="row" th:if="${#lists.isEmpty(files)}">
         <div class="col-12 text-center my-5">
             <h3 class="text-muted">No files have been uploaded yet.</h3>
-            <p>Start by <a href="/">uploading a file</a>.</p>
+            <p>Start by <a href="/file/upload">uploading a file</a>.</p>
         </div>
     </div>
 

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -84,6 +84,15 @@
                     <label class="form-check-label" for="fileListPageEnabled">Enable File List Page</label>
                 </div>
 
+                <!-- Default Home Page -->
+                <div class="mb-3">
+                    <label class="form-label" for="defaultHomePage">Default Home Page</label>
+                    <select class="form-select" id="defaultHomePage" th:field="*{defaultHomePage}">
+                        <option value="upload">Upload Page</option>
+                        <option value="list">File List Page</option>
+                    </select>
+                </div>
+
                 <!-- Enable Admin Dashboard Button -->
                 <div class="form-check mb-3">
                     <input class="form-check-input" id="adminDashboardButtonEnabled"


### PR DESCRIPTION
## Summary
- support a configurable default home page
- migrate DB with default_home_page column
- display dropdown option in admin settings
- redirect `/` to selected page
- adjust nav links to use explicit upload path

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685bee25d5f88322b33062839f568b40