### PR TITLE
Fixed the run command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ mvn clean package
 3. Run the application:
 
 ```
-java -jar target/quickdrop-0.0.1-SNAPSHOT.jar
+java -jar target/quickdrop.jar
 ```
 
 ## Updates


### PR DESCRIPTION
It is no longer written as `quickdrop-0.0.1-SNAPSHOT.jar`, rather `quickdrop.jar`